### PR TITLE
Fixing MCRouter Ansible Operator

### DIFF
--- a/operatorframework/ansible-mcrouter-operator/assets/mcrouter-operator.yaml
+++ b/operatorframework/ansible-mcrouter-operator/assets/mcrouter-operator.yaml
@@ -2,13 +2,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: mcrouter-operator
 rules:
   - apiGroups:
       - ""
     resources:
       - pods
+      - pods/exec
+      - pods/log
       - services
       - endpoints
       - persistentvolumeclaims
@@ -25,35 +26,45 @@ rules:
       - replicasets
       - statefulsets
     verbs:
-      - '*'
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   - apiGroups:
       - monitoring.coreos.com
     resources:
       - servicemonitors
+      - servicemonitor/finalizers
     verbs:
       - get
       - create
+      - update
   - apiGroups:
       - apps
     resourceNames:
       - mcrouter-operator
     resources:
+      - deployments
       - deployments/finalizers
     verbs:
       - update
   - apiGroups:
-      - memcached.example.com
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
       - mcrouter.example.com
     resources:
-      - '*'
       - mcrouters
+      - mcrouters/status
+      - mcrouters/finalizers
     verbs:
-      - '*'
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
 
 ---
 kind: RoleBinding
@@ -102,8 +113,7 @@ spec:
             - mountPath: /tmp/ansible-operator/runner
               name: runner
               readOnly: true
-          securityContext:
-            privileged: true
+          securityContext: {}
         - name: operator
           image: "geerlingguy/mcrouter-operator:0.2.2"
           imagePullPolicy: "Always"
@@ -138,10 +148,34 @@ spec:
     plural: mcrouters
     singular: mcrouter
   scope: Namespaced
-  subresources:
-    status: {}
-  version: v1alpha3
   versions:
-    - name: v1alpha3
-      served: true
-      storage: true
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: Mcrouter is the Schema for the mcrouters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of Mcrouter
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of Mcrouter
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
- Adding required permissions to update finalizers.
- Removing security issue, which pod had privileged permissions.
- Adding required openAPIV3Schema to mcrouter deployment.
- Fix #32 