### PR TITLE
adding in a cd cmd for the Update the Watches File for the helm-operator track

### DIFF
--- a/operatorframework/helm-operator/track.yml
+++ b/operatorframework/helm-operator/track.yml
@@ -137,7 +137,8 @@ challenges:
     The `watches.yaml` file maps a Group, Version, and Kind to a specific Helm Chart. Observe the contents of the `watches.yaml`:
 
     ```
-    cat watches.yaml
+    cd /root/projects/cockroachdb-operator/ && \
+      cat watches.yaml
     ```
   tabs:
   - title: Terminal 1


### PR DESCRIPTION
- Fixes: #66 
- Adding in a `cd` to the proper directory for the hel-operator track so that the user can run the `cat` cmd seamlessly. 

Signed-off-by: Adam D. Cornett <adc@redhat.com>