### PR TITLE
Adding in a gitignore file so project/ide specific files do not get committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# editor and IDE paraphernalia
+.idea
+*.swp
+*.swo
+*~
+.vscode
+
+# MacOS related artifacts
+.DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "extensions.ignoreRecommendations": true
-}


### PR DESCRIPTION
- adding in a gitignore file.
- remove .vscode directory from being tracked by git since it is developer specific.

Signed-off-by: Adam D. Cornett <adc@redhat.com>