### PR TITLE
updating oc command line to 4-10 (for the odo track)

### DIFF
--- a/developing-on-openshift/developing-with-odo/track.yml
+++ b/developing-on-openshift/developing-with-odo/track.yml
@@ -35,6 +35,7 @@ developers:
 - dleblanc@redhat.com
 - dschenck@redhat.com
 - doh@redhat.com
+- ryanj@redhat.com
 private: true
 published: false
-checksum: "7303609014068913956"
+checksum: "8292956828763943396"

--- a/developing-on-openshift/developing-with-odo/track_scripts/setup-container
+++ b/developing-on-openshift/developing-with-odo/track_scripts/setup-container
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export OPENSHIFT_RELEASE_VERSION="4.10.12"
 
 dnf install -y procps-ng iputils bind-utils git java-11-openjdk-devel.x86_64 maven
 
@@ -7,9 +8,8 @@ crc=`nslookup crc |  awk -F': ' 'NR==6 { print $2 } '`
 
 echo "$crc api.crc.testing" >> /etc/hosts
 
-
-curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.9.0/openshift-client-linux-4.9.0.tar.gz -o /tmp/openshift-client-linux-4.9.0.tar.gz
-tar -xvf /tmp/openshift-client-linux-4.9.0.tar.gz -C /usr/bin/
+curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OPENSHIFT_RELEASE_VERSION/openshift-client-linux-$OPENSHIFT_RELEASE_VERSION.tar.gz -o /tmp/openshift-client-linux-$OPENSHIFT_RELEASE_VERSION.tar.gz
+tar -xvf /tmp/openshift-client-linux-$OPENSHIFT_RELEASE_VERSION.tar.gz -C /usr/bin/
 chmod +x /usr/bin/oc
 chmod +x /usr/bin/kubectl
 


### PR DESCRIPTION
This change updates the `oc` command line tool to match the latest OpenShift Local release