### PR TITLE
Update to CRC 4.10.18

### DIFF
--- a/ai-machine-learning/custom-notebooks/config.yml
+++ b/ai-machine-learning/custom-notebooks/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/ai-machine-learning/custom-notebooks/track.yml
+++ b/ai-machine-learning/custom-notebooks/track.yml
@@ -67,7 +67,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -127,7 +127,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -169,7 +169,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -243,7 +243,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -309,7 +309,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code

--- a/ai-machine-learning/custom-notebooks/track_scripts/setup-crc
+++ b/ai-machine-learning/custom-notebooks/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/ai-machine-learning/jupyter-notebooks/config.yml
+++ b/ai-machine-learning/jupyter-notebooks/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/ai-machine-learning/jupyter-notebooks/track.yml
+++ b/ai-machine-learning/jupyter-notebooks/track.yml
@@ -67,7 +67,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -115,7 +115,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -157,7 +157,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -217,7 +217,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -251,7 +251,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code

--- a/ai-machine-learning/jupyter-notebooks/track_scripts/setup-crc
+++ b/ai-machine-learning/jupyter-notebooks/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/ai-machine-learning/jupyter-workspace/config.yml
+++ b/ai-machine-learning/jupyter-workspace/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/ai-machine-learning/jupyter-workspace/track.yml
+++ b/ai-machine-learning/jupyter-workspace/track.yml
@@ -67,7 +67,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -115,7 +115,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -157,7 +157,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -218,7 +218,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -292,7 +292,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code

--- a/ai-machine-learning/jupyter-workspace/track_scripts/setup-crc
+++ b/ai-machine-learning/jupyter-workspace/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/ai-machine-learning/jupyterhub-service/config.yml
+++ b/ai-machine-learning/jupyterhub-service/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/ai-machine-learning/jupyterhub-service/track.yml
+++ b/ai-machine-learning/jupyterhub-service/track.yml
@@ -70,7 +70,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -130,7 +130,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -172,7 +172,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -243,7 +243,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -277,7 +277,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -329,7 +329,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -419,7 +419,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -476,7 +476,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code

--- a/ai-machine-learning/jupyterhub-service/track_scripts/setup-crc
+++ b/ai-machine-learning/jupyterhub-service/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/ai-machine-learning/jupyterhub-workspace/config.yml
+++ b/ai-machine-learning/jupyterhub-workspace/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/ai-machine-learning/jupyterhub-workspace/track.yml
+++ b/ai-machine-learning/jupyterhub-workspace/track.yml
@@ -71,7 +71,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -111,7 +111,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -142,7 +142,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -226,7 +226,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -296,7 +296,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -348,7 +348,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code

--- a/ai-machine-learning/jupyterhub-workspace/track_scripts/setup-crc
+++ b/ai-machine-learning/jupyterhub-workspace/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/ai-machine-learning/prometheus-api-client/config.yml
+++ b/ai-machine-learning/prometheus-api-client/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/ai-machine-learning/prometheus-api-client/track.yml
+++ b/ai-machine-learning/prometheus-api-client/track.yml
@@ -63,7 +63,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -122,7 +122,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -176,7 +176,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code

--- a/ai-machine-learning/prometheus-api-client/track_scripts/setup-crc
+++ b/ai-machine-learning/prometheus-api-client/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/ai-machine-learning/prometheus-timeseries-forecasting/config.yml
+++ b/ai-machine-learning/prometheus-timeseries-forecasting/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/ai-machine-learning/prometheus-timeseries-forecasting/track.yml
+++ b/ai-machine-learning/prometheus-timeseries-forecasting/track.yml
@@ -104,7 +104,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -146,7 +146,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -194,7 +194,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code

--- a/ai-machine-learning/prometheus-timeseries-forecasting/track_scripts/setup-crc
+++ b/ai-machine-learning/prometheus-timeseries-forecasting/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/ai-machine-learning/thoth-s2i-advise/config.yml
+++ b/ai-machine-learning/thoth-s2i-advise/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/ai-machine-learning/thoth-s2i-advise/track.yml
+++ b/ai-machine-learning/thoth-s2i-advise/track.yml
@@ -132,7 +132,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 150
@@ -191,7 +191,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 150
@@ -240,7 +240,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 150
@@ -313,7 +313,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 300

--- a/ai-machine-learning/thoth-s2i-advise/track_scripts/setup-crc
+++ b/ai-machine-learning/thoth-s2i-advise/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/ai-machine-learning/thoth-s2i-provenance/config.yml
+++ b/ai-machine-learning/thoth-s2i-provenance/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/ai-machine-learning/thoth-s2i-provenance/track.yml
+++ b/ai-machine-learning/thoth-s2i-provenance/track.yml
@@ -146,7 +146,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 150
@@ -203,7 +203,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 150
@@ -250,7 +250,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 150
@@ -316,7 +316,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 300
@@ -380,7 +380,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 300

--- a/ai-machine-learning/thoth-s2i-provenance/track_scripts/setup-crc
+++ b/ai-machine-learning/thoth-s2i-provenance/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-on-openshift/deploying-python/01-01-creating-an-initial-project/assignment.md
+++ b/developing-on-openshift/deploying-python/01-01-creating-an-initial-project/assignment.md
@@ -29,7 +29,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/developing-on-openshift/deploying-python/02-02-deploying-using-the-web-console/assignment.md
+++ b/developing-on-openshift/deploying-python/02-02-deploying-using-the-web-console/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/developing-on-openshift/deploying-python/03-03-viewing-the-builder-logs/assignment.md
+++ b/developing-on-openshift/deploying-python/03-03-viewing-the-builder-logs/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/developing-on-openshift/deploying-python/04-04-accessing-the-application/assignment.md
+++ b/developing-on-openshift/deploying-python/04-04-accessing-the-application/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/developing-on-openshift/deploying-python/05-05-deleting-the-application/assignment.md
+++ b/developing-on-openshift/deploying-python/05-05-deleting-the-application/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/developing-on-openshift/deploying-python/06-06-deploying-using-the-command-line/assignment.md
+++ b/developing-on-openshift/deploying-python/06-06-deploying-using-the-command-line/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300
@@ -129,7 +129,7 @@ You'll get output similar to the following:
 
 ```
 NAME             HOST/PORT                                                                  PATH   SERVICES         PORT       TERMINATION   WILDCARD
-blog-django-py   blog-django-py-myproject.crc-gh9wd-master-0.crc.pfrbfxh9ypu7.instruqt.io          blog-django-py   8080-tcp                 None
+blog-django-py   blog-django-py-myproject.crc-5nvrm-master-0.crc.pfrbfxh9ypu7.instruqt.io          blog-django-py   8080-tcp                 None
 ```
 
 # Congratulations!

--- a/developing-on-openshift/deploying-python/07-07-triggering-a-new-build/assignment.md
+++ b/developing-on-openshift/deploying-python/07-07-triggering-a-new-build/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/developing-on-openshift/deploying-python/config.yml
+++ b/developing-on-openshift/deploying-python/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-on-openshift/deploying-python/track_scripts/setup-crc
+++ b/developing-on-openshift/deploying-python/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-on-openshift/developing-with-odo/01-00-application-overview/assignment.md
+++ b/developing-on-openshift/developing-with-odo/01-00-application-overview/assignment.md
@@ -27,7 +27,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 - title: Visual Editor
   type: code

--- a/developing-on-openshift/developing-with-odo/02-01-creating-initial-project/assignment.md
+++ b/developing-on-openshift/developing-with-odo/02-01-creating-initial-project/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 - title: Visual Editor
   type: code

--- a/developing-on-openshift/developing-with-odo/03-02-creating-new-binary-component/assignment.md
+++ b/developing-on-openshift/developing-with-odo/03-02-creating-new-binary-component/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 - title: Visual Editor
   type: code

--- a/developing-on-openshift/developing-with-odo/04-03-deploying-component-from-source-code/assignment.md
+++ b/developing-on-openshift/developing-with-odo/04-03-deploying-component-from-source-code/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 - title: Visual Editor
   type: code

--- a/developing-on-openshift/developing-with-odo/05-04-configuring-components/assignment.md
+++ b/developing-on-openshift/developing-with-odo/05-04-configuring-components/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/developing-on-openshift/developing-with-odo/06-05-exposing-components-to-public/assignment.md
+++ b/developing-on-openshift/developing-with-odo/06-05-exposing-components-to-public/assignment.md
@@ -13,7 +13,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 - title: Visual Editor
   type: code
@@ -73,7 +73,7 @@ Creating Kubernetes resources for component frontend
  ✓  Waiting for component to start [2ms]
 
 Applying URL changes
- ✓  URL frontend: http://frontend-50480802-myproject.crc-gh9wd-master-0.crc.xqhfxqg1mlcp.instruqt.io/ created
+ ✓  URL frontend: http://frontend-50480802-myproject.crc-5nvrm-master-0.crc.xqhfxqg1mlcp.instruqt.io/ created
 
 Syncing to component frontend
  ✓  Checking file changes for pushing [2ms]
@@ -90,7 +90,7 @@ Pushing devfile component "frontend"
 Notice that executing `odo push` returns a URL in the response in the line that starts with `✓  URL frontend`, as shown below:
 
 ```
-http://frontend-app-myproject.crc-gh9wd-master-0.crc.ghds3bg5bjox.instruqt.io/
+http://frontend-app-myproject.crc-5nvrm-master-0.crc.ghds3bg5bjox.instruqt.io/
 ```
 
 |NOTE:|

--- a/developing-on-openshift/developing-with-odo/07-06-making-changes-to-source-code/assignment.md
+++ b/developing-on-openshift/developing-with-odo/07-06-making-changes-to-source-code/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 - title: Visual Editor
   type: code
@@ -120,7 +120,7 @@ You'll get output similar to the following:
 ```
 Found the following URLs for component frontend
 NAME         STATE      URL                                                                               PORT     SECURE     KIND
-frontend     Pushed     http://frontend-app-myproject.crc-gh9wd-master-0.crc.l2bwmvk0f3e4.instruqt.io     8080     false      route
+frontend     Pushed     http://frontend-app-myproject.crc-5nvrm-master-0.crc.l2bwmvk0f3e4.instruqt.io     8080     false      route
 ```
 ----
 # Congratulations!

--- a/developing-on-openshift/developing-with-odo/config.yml
+++ b/developing-on-openshift/developing-with-odo/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-on-openshift/developing-with-odo/track_scripts/setup-crc
+++ b/developing-on-openshift/developing-with-odo/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -209,3 +221,4 @@ done
 
 date
 echo "### Boostrap END ###"
+

--- a/developing-on-openshift/getting-started/01-1explore-cli/assignment.md
+++ b/developing-on-openshift/getting-started/01-1explore-cli/assignment.md
@@ -30,7 +30,7 @@ tabs:
   hostname: crc
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/developing-on-openshift/getting-started/02-2explore-console/assignment.md
+++ b/developing-on-openshift/getting-started/02-2explore-console/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: crc
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/developing-on-openshift/getting-started/03-4scaling/assignment.md
+++ b/developing-on-openshift/getting-started/03-4scaling/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: crc
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/developing-on-openshift/getting-started/04-5routes/assignment.md
+++ b/developing-on-openshift/getting-started/04-5routes/assignment.md
@@ -9,7 +9,7 @@ tabs:
   hostname: crc
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/developing-on-openshift/getting-started/config.yml
+++ b/developing-on-openshift/getting-started/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-on-openshift/getting-started/track_scripts/setup-crc
+++ b/developing-on-openshift/getting-started/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -209,3 +221,4 @@ done
 
 date
 echo "### Boostrap END ###"
+

--- a/developing-on-openshift/helm/config.yml
+++ b/developing-on-openshift/helm/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-on-openshift/helm/track.yml
+++ b/developing-on-openshift/helm/track.yml
@@ -237,7 +237,7 @@ challenges:
     hostname: container
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -355,7 +355,7 @@ challenges:
     hostname: container
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code
@@ -485,7 +485,7 @@ challenges:
     hostname: container
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code

--- a/developing-on-openshift/helm/track_scripts/setup-crc
+++ b/developing-on-openshift/helm/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-on-openshift/port-forwarding/config.yml
+++ b/developing-on-openshift/port-forwarding/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-on-openshift/port-forwarding/track_scripts/setup-crc
+++ b/developing-on-openshift/port-forwarding/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-on-openshift/serverless/config.yml
+++ b/developing-on-openshift/serverless/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-on-openshift/serverless/track.yml
+++ b/developing-on-openshift/serverless/track.yml
@@ -217,7 +217,7 @@ challenges:
     hostname: container
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 360
@@ -390,7 +390,7 @@ challenges:
     See the `NAME` of the route, the `URL`, as well as if it is `READY` (your URL will be different):
     ```bash
     NAME      URL                                                                                  READY
-    greeter   https://greeter-serverless-tutorial.crc-gh9wd-master-0.crc.2rtmqs1ojyed.instruqt.io  True
+    greeter   https://greeter-serverless-tutorial.crc-5nvrm-master-0.crc.2rtmqs1ojyed.instruqt.io  True
     ```
 
     ### Revision
@@ -456,7 +456,7 @@ challenges:
     hostname: container
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 360
@@ -601,7 +601,7 @@ challenges:
     hostname: container
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 360
@@ -699,7 +699,7 @@ challenges:
     hostname: container
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 360
@@ -927,7 +927,7 @@ challenges:
     hostname: container
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 360

--- a/developing-on-openshift/serverless/track_scripts/setup-crc
+++ b/developing-on-openshift/serverless/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-on-openshift/transferring-files/02-02-downloading-files-from-a-container/assignment.md
+++ b/developing-on-openshift/transferring-files/02-02-downloading-files-from-a-container/assignment.md
@@ -124,7 +124,7 @@ export APP_ROUTE=`oc get route simplemessage -n myproject -o jsonpath='{"http://
 You'll get output similar to the following:
 
 ```
-http://simplemessage-myproject.crc-gh9wd-master-0.crc.ogrx0anbjp74.instruqt.io
+http://simplemessage-myproject.crc-5nvrm-master-0.crc.ogrx0anbjp74.instruqt.io
 ```
 
 Remember: The output shown above is special to this running instance of OpenShift. The URL you get when you run this track will be different.

--- a/developing-on-openshift/transferring-files/03-03-uploading-files-to-a-container/assignment.md
+++ b/developing-on-openshift/transferring-files/03-03-uploading-files-to-a-container/assignment.md
@@ -102,7 +102,7 @@ export APP_ROUTE=`oc get route simplemessage -n myproject -o jsonpath='{"http://
 You'll get output similar to the following:
 
 ```
-http://simplemessage-myproject.crc-gh9wd-master-0.crc.ai7oaxyso7ih.instruqt.io
+http://simplemessage-myproject.crc-5nvrm-master-0.crc.ai7oaxyso7ih.instruqt.io
 ```
 
 The output above is the URL to the SimpleMessage application running in this OpenShift cluster. The URL you create will be different. Remember: The actual structure of the URL is special to the running instance of OpenShift.

--- a/developing-on-openshift/transferring-files/04-04-synchronizing-files-with-a-container/assignment.md
+++ b/developing-on-openshift/transferring-files/04-04-synchronizing-files-with-a-container/assignment.md
@@ -126,7 +126,7 @@ export APP_ROUTE=`oc get route simplemessage -n myproject -o jsonpath='{"http://
 You'll get output similar to the following. (Your actual URL will be different):
 
 ```
-http://simplemessage-myproject.crc-gh9wd-master-0.crc.ai7oaxyso7ih.instruqt.io
+http://simplemessage-myproject.crc-5nvrm-master-0.crc.ai7oaxyso7ih.instruqt.io
 ```
 
 ----

--- a/developing-on-openshift/transferring-files/config.yml
+++ b/developing-on-openshift/transferring-files/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-on-openshift/transferring-files/track_scripts/setup-crc
+++ b/developing-on-openshift/transferring-files/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-kogito/dmn/config.yml
+++ b/developing-with-kogito/dmn/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-kogito/dmn/track_scripts/setup-crc
+++ b/developing-with-kogito/dmn/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-kogito/getting-started/config.yml
+++ b/developing-with-kogito/getting-started/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-kogito/getting-started/track_scripts/setup-crc
+++ b/developing-with-kogito/getting-started/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-kogito/optaplanner-knapsack/config.yml
+++ b/developing-with-kogito/optaplanner-knapsack/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-kogito/optaplanner-knapsack/track_scripts/setup-crc
+++ b/developing-with-kogito/optaplanner-knapsack/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-kogito/rest-service-integration/config.yml
+++ b/developing-with-kogito/rest-service-integration/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-kogito/rest-service-integration/track_scripts/setup-crc
+++ b/developing-with-kogito/rest-service-integration/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-kogito/rules/config.yml
+++ b/developing-with-kogito/rules/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-kogito/rules/track_scripts/setup-crc
+++ b/developing-with-kogito/rules/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-kogito/service-task-cdi/config.yml
+++ b/developing-with-kogito/service-task-cdi/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-kogito/service-task-cdi/track_scripts/setup-crc
+++ b/developing-with-kogito/service-task-cdi/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-quarkus/getting-started/05-05-deploy-to-openshift/assignment.md
+++ b/developing-with-quarkus/getting-started/05-05-deploy-to-openshift/assignment.md
@@ -20,7 +20,7 @@ tabs:
   hostname: crc
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 500

--- a/developing-with-quarkus/getting-started/06-06-scaling/assignment.md
+++ b/developing-with-quarkus/getting-started/06-06-scaling/assignment.md
@@ -20,7 +20,7 @@ tabs:
   hostname: crc
 - title: OpenShift Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 500

--- a/developing-with-quarkus/getting-started/config.yml
+++ b/developing-with-quarkus/getting-started/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-quarkus/getting-started/track_scripts/setup-crc
+++ b/developing-with-quarkus/getting-started/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -144,16 +144,12 @@ oc patch -p '{"spec": {"host": "downloads-openshift-console.'$HOSTNAME'.crc.'$IN
 
 oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAME'.crc.'$INSTRUQT_PARTICIPANT_ID'.instruqt.io"}}' route default-route -n openshift-image-registry --type=merge
 
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc
 
 #wait until cluster operators are "available"
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -180,11 +176,28 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+export HOME="/root"
+curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java_graalvm.sh | bash
+
+mkdir -p /root/projects/quarkus
+echo "-w \"\n\"" >> ~/.curlrc
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -214,8 +227,3 @@ done
 date
 echo "### Boostrap END ###"
 
-export HOME="/root"
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java_graalvm.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc

--- a/developing-with-quarkus/kafka/07-07-deploy-and-test/assignment.md
+++ b/developing-with-quarkus/kafka/07-07-deploy-and-test/assignment.md
@@ -17,7 +17,7 @@ tabs:
   path: /root/projects/rhoar-getting-started/quarkus/kafka
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: intermediate
 timelimit: 428

--- a/developing-with-quarkus/kafka/config.yml
+++ b/developing-with-quarkus/kafka/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-quarkus/kafka/track_scripts/setup-crc
+++ b/developing-with-quarkus/kafka/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -144,16 +144,12 @@ oc patch -p '{"spec": {"host": "downloads-openshift-console.'$HOSTNAME'.crc.'$IN
 
 oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAME'.crc.'$INSTRUQT_PARTICIPANT_ID'.instruqt.io"}}' route default-route -n openshift-image-registry --type=merge
 
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc
 
 #wait until cluster operators are "available"
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -180,11 +176,29 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+export HOME="/root"
+curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
+
+mkdir -p /root/projects/quarkus
+echo "-w \"\n\"" >> ~/.curlrc
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -214,8 +228,3 @@ done
 date
 echo "### Boostrap END ###"
 
-export HOME="/root"
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc

--- a/developing-with-quarkus/monitoring/01-01-install-prometheus/assignment.md
+++ b/developing-with-quarkus/monitoring/01-01-install-prometheus/assignment.md
@@ -35,7 +35,7 @@ tabs:
   path: /root/projects/quarkus
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 200

--- a/developing-with-quarkus/monitoring/04-04-deploy-to-openshift/assignment.md
+++ b/developing-with-quarkus/monitoring/04-04-deploy-to-openshift/assignment.md
@@ -16,7 +16,7 @@ tabs:
   path: /root/projects/quarkus/primes
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 200

--- a/developing-with-quarkus/monitoring/06-06-install-grafana/assignment.md
+++ b/developing-with-quarkus/monitoring/06-06-install-grafana/assignment.md
@@ -94,7 +94,7 @@ oc get route origin-grafana -n quarkus -o jsonpath='{"http://"}{.spec.host}'
 You'll get output similar to the following, but the exact URL will be different for your instance:
 
 ```
-http://origin-grafana-quarkus.crc-gh9wd-master-0.crc.ihd2pmeddknj.instruqt.io
+http://origin-grafana-quarkus.crc-5nvrm-master-0.crc.ihd2pmeddknj.instruqt.io
 ```
 
 ----

--- a/developing-with-quarkus/monitoring/config.yml
+++ b/developing-with-quarkus/monitoring/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-quarkus/monitoring/track_scripts/setup-crc
+++ b/developing-with-quarkus/monitoring/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -144,16 +144,12 @@ oc patch -p '{"spec": {"host": "downloads-openshift-console.'$HOSTNAME'.crc.'$IN
 
 oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAME'.crc.'$INSTRUQT_PARTICIPANT_ID'.instruqt.io"}}' route default-route -n openshift-image-registry --type=merge
 
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc
 
 #wait until cluster operators are "available"
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -180,11 +176,28 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+export HOME="/root"
+curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java_graalvm.sh | bash
+
+mkdir -p /root/projects/quarkus
+echo "-w \"\n\"" >> ~/.curlrc
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -214,8 +227,3 @@ done
 date
 echo "### Boostrap END ###"
 
-export HOME="/root"
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc

--- a/developing-with-quarkus/panache-reactive/02-02-remote-dev/assignment.md
+++ b/developing-with-quarkus/panache-reactive/02-02-remote-dev/assignment.md
@@ -16,7 +16,7 @@ tabs:
   path: /root/projects/rhoar-getting-started/quarkus/panache-reactive
 - title: OpenShift Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 500

--- a/developing-with-quarkus/panache-reactive/06-06-exercise-table/assignment.md
+++ b/developing-with-quarkus/panache-reactive/06-06-exercise-table/assignment.md
@@ -16,7 +16,7 @@ tabs:
   path: /root/projects/rhoar-getting-started/quarkus/panache-reactive
 - title: OpenShift Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 500

--- a/developing-with-quarkus/panache-reactive/config.yml
+++ b/developing-with-quarkus/panache-reactive/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-quarkus/panache-reactive/track_scripts/setup-crc
+++ b/developing-with-quarkus/panache-reactive/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -144,16 +144,12 @@ oc patch -p '{"spec": {"host": "downloads-openshift-console.'$HOSTNAME'.crc.'$IN
 
 oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAME'.crc.'$INSTRUQT_PARTICIPANT_ID'.instruqt.io"}}' route default-route -n openshift-image-registry --type=merge
 
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc
 
 #wait until cluster operators are "available"
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -180,11 +176,28 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+export HOME="/root"
+curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java_graalvm.sh | bash
+
+mkdir -p /root/projects/quarkus
+echo "-w \"\n\"" >> ~/.curlrc
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -214,8 +227,3 @@ done
 date
 echo "### Boostrap END ###"
 
-export HOME="/root"
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc

--- a/developing-with-quarkus/panache/02-02-remote-dev/assignment.md
+++ b/developing-with-quarkus/panache/02-02-remote-dev/assignment.md
@@ -20,7 +20,7 @@ tabs:
   path: /root/projects/rhoar-getting-started/quarkus/panache
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300
@@ -363,7 +363,7 @@ echo $APP_URL
 You'll get output similar to, but not exactly like, the following:
 
 ```
-http://people-quarkus.crc-gh9wd-master-0.crc.nqguvly2ktsc.instruqt.io
+http://people-quarkus.crc-5nvrm-master-0.crc.nqguvly2ktsc.instruqt.io
 ```
 
 ----

--- a/developing-with-quarkus/panache/06-06-exercise-table/assignment.md
+++ b/developing-with-quarkus/panache/06-06-exercise-table/assignment.md
@@ -20,7 +20,7 @@ tabs:
   path: /root/projects/rhoar-getting-started/quarkus/panache
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/developing-with-quarkus/panache/config.yml
+++ b/developing-with-quarkus/panache/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-quarkus/panache/track_scripts/setup-crc
+++ b/developing-with-quarkus/panache/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -144,16 +144,12 @@ oc patch -p '{"spec": {"host": "downloads-openshift-console.'$HOSTNAME'.crc.'$IN
 
 oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAME'.crc.'$INSTRUQT_PARTICIPANT_ID'.instruqt.io"}}' route default-route -n openshift-image-registry --type=merge
 
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc
 
 #wait until cluster operators are "available"
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -180,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -214,8 +222,3 @@ done
 date
 echo "### Boostrap END ###"
 
-export HOME="/root"
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc

--- a/developing-with-quarkus/qute/config.yml
+++ b/developing-with-quarkus/qute/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-quarkus/qute/track_scripts/setup-crc
+++ b/developing-with-quarkus/qute/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -144,16 +144,12 @@ oc patch -p '{"spec": {"host": "downloads-openshift-console.'$HOSTNAME'.crc.'$IN
 
 oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAME'.crc.'$INSTRUQT_PARTICIPANT_ID'.instruqt.io"}}' route default-route -n openshift-image-registry --type=merge
 
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc
 
 #wait until cluster operators are "available"
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -180,11 +176,28 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+export HOME="/root"
+curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java_graalvm.sh | bash
+
+mkdir -p /root/projects/quarkus
+echo "-w \"\n\"" >> ~/.curlrc
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -214,8 +227,3 @@ done
 date
 echo "### Boostrap END ###"
 
-export HOME="/root"
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc

--- a/developing-with-quarkus/reactive-sql/02-02-remote-dev/assignment.md
+++ b/developing-with-quarkus/reactive-sql/02-02-remote-dev/assignment.md
@@ -18,7 +18,7 @@ tabs:
   path: /root/projects/rhoar-getting-started/quarkus/reactive-sql
 - title: OpenShift Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: intermediate
 timelimit: 240
@@ -303,7 +303,7 @@ echo $APP_ROUTE
 You'll get output similar to the following:
 
 ```
-http://reactive-sql-reactive-sql.crc-gh9wd-master-0.crc.hbie33wmyvpb.instruqt.io
+http://reactive-sql-reactive-sql.crc-5nvrm-master-0.crc.hbie33wmyvpb.instruqt.io
 ```
 
 (The actual details of your URL will differ because each running instance of OpenShift will have a unique URL.)

--- a/developing-with-quarkus/reactive-sql/config.yml
+++ b/developing-with-quarkus/reactive-sql/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-quarkus/reactive-sql/track_scripts/setup-crc
+++ b/developing-with-quarkus/reactive-sql/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -144,16 +144,12 @@ oc patch -p '{"spec": {"host": "downloads-openshift-console.'$HOSTNAME'.crc.'$IN
 
 oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAME'.crc.'$INSTRUQT_PARTICIPANT_ID'.instruqt.io"}}' route default-route -n openshift-image-registry --type=merge
 
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc
 
 #wait until cluster operators are "available"
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -180,11 +176,28 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+export HOME="/root"
+curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java_graalvm.sh | bash
+
+mkdir -p /root/projects/quarkus
+echo "-w \"\n\"" >> ~/.curlrc
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -214,8 +227,3 @@ done
 date
 echo "### Boostrap END ###"
 
-export HOME="/root"
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc

--- a/developing-with-quarkus/spring/06-06-deploy-and-test/assignment.md
+++ b/developing-with-quarkus/spring/06-06-deploy-and-test/assignment.md
@@ -19,7 +19,7 @@ tabs:
   hostname: crc
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: intermediate
 timelimit: 500

--- a/developing-with-quarkus/spring/config.yml
+++ b/developing-with-quarkus/spring/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-quarkus/spring/track_scripts/setup-crc
+++ b/developing-with-quarkus/spring/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -144,16 +144,12 @@ oc patch -p '{"spec": {"host": "downloads-openshift-console.'$HOSTNAME'.crc.'$IN
 
 oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAME'.crc.'$INSTRUQT_PARTICIPANT_ID'.instruqt.io"}}' route default-route -n openshift-image-registry --type=merge
 
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc
 
 #wait until cluster operators are "available"
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -180,11 +176,28 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+export HOME="/root"
+curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java_graalvm.sh | bash
+
+mkdir -p /root/projects/quarkus
+echo "-w \"\n\"" >> ~/.curlrc
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -214,8 +227,3 @@ done
 date
 echo "### Boostrap END ###"
 
-export HOME="/root"
-curl https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/scripts/install_java.sh | bash
-
-mkdir -p /root/projects/quarkus
-echo "-w \"\n\"" >> ~/.curlrc

--- a/developing-with-spring/microservices-1/config.yml
+++ b/developing-with-spring/microservices-1/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-spring/microservices-1/track.yml
+++ b/developing-with-spring/microservices-1/track.yml
@@ -189,7 +189,7 @@ challenges:
     path: /root/projects/rhoar-getting-started/spring/microservices-externalized-config
   - title: OpenShift Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 1000

--- a/developing-with-spring/microservices-1/track_scripts/setup-crc
+++ b/developing-with-spring/microservices-1/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-spring/monitoring/config.yml
+++ b/developing-with-spring/monitoring/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-spring/monitoring/track.yml
+++ b/developing-with-spring/monitoring/track.yml
@@ -168,7 +168,7 @@ challenges:
     path: /root/projects/rhoar-getting-started/spring/spring-monitoring
   - title: OpenShift Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 1000

--- a/developing-with-spring/monitoring/track_scripts/setup-crc
+++ b/developing-with-spring/monitoring/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-spring/spring-db-access/config.yml
+++ b/developing-with-spring/spring-db-access/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-spring/spring-db-access/track_scripts/setup-crc
+++ b/developing-with-spring/spring-db-access/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-spring/spring-getting-started/config.yml
+++ b/developing-with-spring/spring-getting-started/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-spring/spring-getting-started/track.yml
+++ b/developing-with-spring/spring-getting-started/track.yml
@@ -648,7 +648,7 @@ challenges:
     path: /root/projects/rhoar-getting-started/spring/spring-rhoar-intro
   - title: OpenShift Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 600

--- a/developing-with-spring/spring-getting-started/track_scripts/setup-crc
+++ b/developing-with-spring/spring-getting-started/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-spring/spring-messaging/config.yml
+++ b/developing-with-spring/spring-messaging/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-spring/spring-messaging/track.yml
+++ b/developing-with-spring/spring-messaging/track.yml
@@ -414,7 +414,7 @@ challenges:
     path: /root/projects/rhoar-getting-started/spring/spring-messaging
   - title: OpenShift Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 750

--- a/developing-with-spring/spring-messaging/track_scripts/setup-crc
+++ b/developing-with-spring/spring-messaging/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-spring/spring-rest-services/config.yml
+++ b/developing-with-spring/spring-rest-services/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-spring/spring-rest-services/track.yml
+++ b/developing-with-spring/spring-rest-services/track.yml
@@ -393,7 +393,7 @@ challenges:
     path: /root/projects/rhoar-getting-started/spring/spring-rest-services
   - title: OpenShift Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 1000

--- a/developing-with-spring/spring-rest-services/track_scripts/setup-crc
+++ b/developing-with-spring/spring-rest-services/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-vertx/audit-service/config.yml
+++ b/developing-with-vertx/audit-service/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-vertx/audit-service/track_scripts/setup-crc
+++ b/developing-with-vertx/audit-service/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-vertx/compulsive-traders/config.yml
+++ b/developing-with-vertx/compulsive-traders/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-vertx/compulsive-traders/track_scripts/setup-crc
+++ b/developing-with-vertx/compulsive-traders/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-vertx/getting-started-vertx/config.yml
+++ b/developing-with-vertx/getting-started-vertx/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-vertx/getting-started-vertx/track_scripts/setup-crc
+++ b/developing-with-vertx/getting-started-vertx/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-vertx/portfolio-service/config.yml
+++ b/developing-with-vertx/portfolio-service/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-vertx/portfolio-service/track_scripts/setup-crc
+++ b/developing-with-vertx/portfolio-service/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/developing-with-vertx/quote-generator/config.yml
+++ b/developing-with-vertx/quote-generator/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/developing-with-vertx/quote-generator/track_scripts/setup-crc
+++ b/developing-with-vertx/quote-generator/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/enterprise-java/amq-getting-started-broker/config.yml
+++ b/enterprise-java/amq-getting-started-broker/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/enterprise-java/amq-getting-started-broker/track_scripts/setup-crc
+++ b/enterprise-java/amq-getting-started-broker/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/enterprise-java/camel-k-basic/config.yml
+++ b/enterprise-java/camel-k-basic/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/enterprise-java/camel-k-basic/track_scripts/setup-crc
+++ b/enterprise-java/camel-k-basic/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/enterprise-java/middleware-javaee8/config.yml
+++ b/enterprise-java/middleware-javaee8/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/enterprise-java/middleware-javaee8/track.yml
+++ b/enterprise-java/middleware-javaee8/track.yml
@@ -236,7 +236,7 @@ challenges:
     path: /root/projects/rhoar-getting-started/javaee/weather-app/
   - title: OpenShift Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: intermediate
   timelimit: 600

--- a/enterprise-java/middleware-javaee8/track_scripts/setup-crc
+++ b/enterprise-java/middleware-javaee8/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/enterprise-java/rhoar-getting-started-rhdg/config.yml
+++ b/enterprise-java/rhoar-getting-started-rhdg/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/enterprise-java/rhoar-getting-started-rhdg/track_scripts/setup-crc
+++ b/enterprise-java/rhoar-getting-started-rhdg/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/examples/getting-started-4-10/01-1explore-cli/assignment.md
+++ b/examples/getting-started-4-10/01-1explore-cli/assignment.md
@@ -30,7 +30,7 @@ tabs:
   hostname: crc
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/examples/getting-started-4-10/02-2explore-console/assignment.md
+++ b/examples/getting-started-4-10/02-2explore-console/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: crc
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/examples/getting-started-4-10/03-4scaling/assignment.md
+++ b/examples/getting-started-4-10/03-4scaling/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: crc
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/examples/getting-started-4-10/04-5routes/assignment.md
+++ b/examples/getting-started-4-10/04-5routes/assignment.md
@@ -9,7 +9,7 @@ tabs:
   hostname: crc
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/examples/getting-started-4-10/config.yml
+++ b/examples/getting-started-4-10/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/examples/getting-started-4-10/track_scripts/setup-crc
+++ b/examples/getting-started-4-10/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/examples/openshift-example-track-with-fedora-sidecar/config.yml
+++ b/examples/openshift-example-track-with-fedora-sidecar/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/examples/openshift-example-track-with-fedora-sidecar/track_scripts/setup-crc
+++ b/examples/openshift-example-track-with-fedora-sidecar/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/examples/openshift-example-track/config.yml
+++ b/examples/openshift-example-track/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/examples/openshift-example-track/track_scripts/setup-crc
+++ b/examples/openshift-example-track/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/gitops/getting-started/config.yml
+++ b/gitops/getting-started/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/gitops/getting-started/track_scripts/setup-crc
+++ b/gitops/getting-started/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/gitops/kustomize/config.yml
+++ b/gitops/kustomize/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/gitops/kustomize/track_scripts/setup-crc
+++ b/gitops/kustomize/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/gitops/pipelines/config.yml
+++ b/gitops/pipelines/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/gitops/pipelines/track_scripts/setup-crc
+++ b/gitops/pipelines/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/gitops/syncwaves-hooks/config.yml
+++ b/gitops/syncwaves-hooks/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/gitops/syncwaves-hooks/track_scripts/setup-crc
+++ b/gitops/syncwaves-hooks/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/gitops/working-with-helm/config.yml
+++ b/gitops/working-with-helm/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/gitops/working-with-helm/track_scripts/setup-crc
+++ b/gitops/working-with-helm/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/kafka/kafka-basic/config.yml
+++ b/kafka/kafka-basic/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/kafka/kafka-basic/track_scripts/setup-crc
+++ b/kafka/kafka-basic/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/kafka/kafka-debezium/config.yml
+++ b/kafka/kafka-debezium/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/kafka/kafka-debezium/track_scripts/setup-crc
+++ b/kafka/kafka-debezium/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/kafka/kafka-http-bridge/config.yml
+++ b/kafka/kafka-http-bridge/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/kafka/kafka-http-bridge/track_scripts/setup-crc
+++ b/kafka/kafka-http-bridge/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/kafka/kafka-quarkus/config.yml
+++ b/kafka/kafka-quarkus/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/kafka/kafka-quarkus/track_scripts/setup-crc
+++ b/kafka/kafka-quarkus/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/operatorframework/ansible-k8s-modules/config.yml
+++ b/operatorframework/ansible-k8s-modules/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/operatorframework/ansible-k8s-modules/track_scripts/setup-crc
+++ b/operatorframework/ansible-k8s-modules/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/operatorframework/ansible-mcrouter-operator/config.yml
+++ b/operatorframework/ansible-mcrouter-operator/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/operatorframework/ansible-mcrouter-operator/track_scripts/setup-crc
+++ b/operatorframework/ansible-mcrouter-operator/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/operatorframework/ansible-operator-overview/config.yml
+++ b/operatorframework/ansible-operator-overview/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/operatorframework/ansible-operator-overview/track_scripts/setup-crc
+++ b/operatorframework/ansible-operator-overview/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/operatorframework/etcd-operator/config.yml
+++ b/operatorframework/etcd-operator/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/operatorframework/etcd-operator/track_scripts/setup-crc
+++ b/operatorframework/etcd-operator/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/operatorframework/go-operator-memcached/config.yml
+++ b/operatorframework/go-operator-memcached/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/operatorframework/go-operator-memcached/track_scripts/setup-crc
+++ b/operatorframework/go-operator-memcached/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/operatorframework/go-operator-podset/config.yml
+++ b/operatorframework/go-operator-podset/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/operatorframework/go-operator-podset/track_scripts/setup-crc
+++ b/operatorframework/go-operator-podset/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/operatorframework/helm-operator-memcached/config.yml
+++ b/operatorframework/helm-operator-memcached/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/operatorframework/helm-operator-memcached/track_scripts/setup-crc
+++ b/operatorframework/helm-operator-memcached/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/operatorframework/helm-operator/config.yml
+++ b/operatorframework/helm-operator/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/operatorframework/helm-operator/track.yml
+++ b/operatorframework/helm-operator/track.yml
@@ -129,7 +129,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 200
@@ -154,7 +154,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 200
@@ -191,7 +191,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 200
@@ -280,7 +280,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 200
@@ -312,7 +312,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 200
@@ -361,7 +361,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 200
@@ -393,7 +393,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 200
@@ -441,7 +441,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 200
@@ -473,7 +473,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 200

--- a/operatorframework/helm-operator/track_scripts/setup-crc
+++ b/operatorframework/helm-operator/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/operatorframework/k8s-api-fundamentals/config.yml
+++ b/operatorframework/k8s-api-fundamentals/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/operatorframework/k8s-api-fundamentals/track_scripts/setup-crc
+++ b/operatorframework/k8s-api-fundamentals/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/operatorframework/operator-lifecycle-manager/config.yml
+++ b/operatorframework/operator-lifecycle-manager/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/operatorframework/operator-lifecycle-manager/track.yml
+++ b/operatorframework/operator-lifecycle-manager/track.yml
@@ -118,7 +118,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 225
@@ -206,7 +206,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 225
@@ -248,7 +248,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 225
@@ -348,7 +348,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 225
@@ -431,7 +431,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 225
@@ -492,7 +492,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 225
@@ -522,7 +522,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 225
@@ -571,7 +571,7 @@ challenges:
     path: /root
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   difficulty: basic
   timelimit: 225

--- a/operatorframework/operator-lifecycle-manager/track_scripts/setup-crc
+++ b/operatorframework/operator-lifecycle-manager/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/persistence/persistent-elasticsearch/config.yml
+++ b/persistence/persistent-elasticsearch/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/persistence/persistent-elasticsearch/track_scripts/setup-crc
+++ b/persistence/persistent-elasticsearch/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/persistence/persistent-intro/config.yml
+++ b/persistence/persistent-intro/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/persistence/persistent-intro/track_scripts/setup-crc
+++ b/persistence/persistent-intro/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/playgrounds/openshift410/config.yml
+++ b/playgrounds/openshift410/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/playgrounds/openshift410/track.yml
+++ b/playgrounds/openshift410/track.yml
@@ -190,7 +190,7 @@ challenges:
     hostname: crc
   - title: Web Console
     type: website
-    url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+    url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
     new_window: true
   - title: Visual Editor
     type: code

--- a/playgrounds/openshift410/track_scripts/setup-crc
+++ b/playgrounds/openshift410/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/serverless/camel-k-basic/01-step1/assignment.md
+++ b/serverless/camel-k-basic/01-step1/assignment.md
@@ -26,7 +26,7 @@ tabs:
   hostname: crc
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 375

--- a/serverless/camel-k-basic/02-step2/assignment.md
+++ b/serverless/camel-k-basic/02-step2/assignment.md
@@ -13,7 +13,7 @@ tabs:
   path: /root/camel-basic
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 375

--- a/serverless/camel-k-basic/03-step3/assignment.md
+++ b/serverless/camel-k-basic/03-step3/assignment.md
@@ -13,7 +13,7 @@ tabs:
   path: /root/camel-basic
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 375

--- a/serverless/camel-k-basic/04-step4/assignment.md
+++ b/serverless/camel-k-basic/04-step4/assignment.md
@@ -13,7 +13,7 @@ tabs:
   path: /root/camel-basic
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 375

--- a/serverless/camel-k-basic/config.yml
+++ b/serverless/camel-k-basic/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/serverless/camel-k-basic/track_scripts/setup-crc
+++ b/serverless/camel-k-basic/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,32 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+curl -sL https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/serverless/camel-k-basic/scripts/operator-install.yaml -o /opt/operator-install.yaml
+
+CAMELK_VERSION=1.6.7
+
+curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/camel-k/$CAMELK_VERSION/camel-k-client-$CAMELK_VERSION-linux-64bit.tar.gz | tar -xz -C /usr/local/bin
+chmod +x /usr/local/bin/kamel
+
+mkdir -p /root/camel-basic
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -210,12 +231,3 @@ done
 date
 echo "### Boostrap END ###"
 
-
-curl -sL https://raw.githubusercontent.com/openshift-instruqt/instruqt/master/serverless/camel-k-basic/scripts/operator-install.yaml -o /opt/operator-install.yaml
-
-CAMELK_VERSION=1.6.7
-
-curl -sL https://mirror.openshift.com/pub/openshift-v4/clients/camel-k/$CAMELK_VERSION/camel-k-client-$CAMELK_VERSION-linux-64bit.tar.gz | tar -xz -C /usr/local/bin
-chmod +x /usr/local/bin/kamel
-
-mkdir -p /root/camel-basic

--- a/serverless/camel-k-eventing/config.yml
+++ b/serverless/camel-k-eventing/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/serverless/camel-k-eventing/track_scripts/setup-crc
+++ b/serverless/camel-k-eventing/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/serverless/camel-k-serving/config.yml
+++ b/serverless/camel-k-serving/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/serverless/camel-k-serving/track_scripts/setup-crc
+++ b/serverless/camel-k-serving/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/serverless/camel-kafka-connector/config.yml
+++ b/serverless/camel-kafka-connector/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/serverless/camel-kafka-connector/track_scripts/setup-crc
+++ b/serverless/camel-kafka-connector/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/serverless/serverless/config.yml
+++ b/serverless/serverless/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/serverless/serverless/track_scripts/setup-crc
+++ b/serverless/serverless/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/servicemesh/1-introduction/config.yml
+++ b/servicemesh/1-introduction/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/servicemesh/1-introduction/track_scripts/setup-crc
+++ b/servicemesh/1-introduction/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/subsystems/container-internals-lab-2-0-part-1/config.yml
+++ b/subsystems/container-internals-lab-2-0-part-1/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/subsystems/container-internals-lab-2-0-part-1/track_scripts/setup-crc
+++ b/subsystems/container-internals-lab-2-0-part-1/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/subsystems/container-internals-lab-2-0-part-2/config.yml
+++ b/subsystems/container-internals-lab-2-0-part-2/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/subsystems/container-internals-lab-2-0-part-2/track_scripts/setup-crc
+++ b/subsystems/container-internals-lab-2-0-part-2/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/subsystems/container-internals-lab-2-0-part-3/config.yml
+++ b/subsystems/container-internals-lab-2-0-part-3/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/subsystems/container-internals-lab-2-0-part-3/track_scripts/setup-crc
+++ b/subsystems/container-internals-lab-2-0-part-3/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/subsystems/container-internals-lab-2-0-part-4/config.yml
+++ b/subsystems/container-internals-lab-2-0-part-4/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/subsystems/container-internals-lab-2-0-part-4/track_scripts/setup-crc
+++ b/subsystems/container-internals-lab-2-0-part-4/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/subsystems/container-internals-lab-2-0-part-5/config.yml
+++ b/subsystems/container-internals-lab-2-0-part-5/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/subsystems/container-internals-lab-2-0-part-5/track_scripts/setup-crc
+++ b/subsystems/container-internals-lab-2-0-part-5/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/subsystems/container-internals-lab-2-0-part-6/config.yml
+++ b/subsystems/container-internals-lab-2-0-part-6/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/subsystems/container-internals-lab-2-0-part-6/track_scripts/setup-crc
+++ b/subsystems/container-internals-lab-2-0-part-6/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/subsystems/container-internals-lab-2-0-part-7/config.yml
+++ b/subsystems/container-internals-lab-2-0-part-7/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: rhel
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   shell: /bin/bash
   environment:
     TERM: xterm

--- a/using-the-cluster/cluster-access/01-01-logging-in-via-the-web-console/assignment.md
+++ b/using-the-cluster/cluster-access/01-01-logging-in-via-the-web-console/assignment.md
@@ -60,7 +60,7 @@ oc get routes console -n openshift-console -o jsonpath='{"https://"}{.spec.host}
 You'll get the URL to the web console that is special to your instance of OpenShift running in the Instruqt interactive learning environment. The following is an example URL. **Yours will be different**.
 
 ```
-https://console-openshift-console.crc-gh9wd-master-0.crc.q82njnglzds2.instruqt.io
+https://console-openshift-console.crc-5nvrm-master-0.crc.q82njnglzds2.instruqt.io
 ```
 
 ----

--- a/using-the-cluster/cluster-access/02-02-logging-in-via-the-command-line/assignment.md
+++ b/using-the-cluster/cluster-access/02-02-logging-in-via-the-command-line/assignment.md
@@ -97,7 +97,7 @@ In the case where an external authentication service is used as the identity pro
 When you log in at the command line using `oc login` without providing the username (`-u`) and password (`-p`) options, you will get an error similar to the following. The response directs you to an authentication server:
 
 ```
-You must obtain an API token by visiting https://oauth-openshift.crc-gh9wd-master-0.crc.d9avlfzludvk.instruqt.io/oauth/token/request
+You must obtain an API token by visiting https://oauth-openshift.crc-5nvrm-master-0.crc.d9avlfzludvk.instruqt.io/oauth/token/request
 ```
 
 Once you get your API token, you receive a user's login credentials from the authentication server according to that server's authentication process.

--- a/using-the-cluster/cluster-access/04-04-switching-between-accounts/assignment.md
+++ b/using-the-cluster/cluster-access/04-04-switching-between-accounts/assignment.md
@@ -111,7 +111,7 @@ oc config get-contexts
 You'll get output similar to the following:
 
 ```
-root@crc-gh9wd-master-0 /]# oc config get-contexts
+root@crc-5nvrm-master-0 /]# oc config get-contexts
 CURRENT   NAME                                         CLUSTER                AUTHINFO                         NAMESPACE
           /api-crc-testing:6443/user1                  api-crc-testing:6443   user1/api-crc-testing:6443
           admin                                        crc                    admin

--- a/using-the-cluster/cluster-access/config.yml
+++ b/using-the-cluster/cluster-access/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/using-the-cluster/cluster-access/track_scripts/setup-crc
+++ b/using-the-cluster/cluster-access/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -209,3 +221,4 @@ done
 
 date
 echo "### Boostrap END ###"
+

--- a/using-the-cluster/deploy-prometheus-grafana/config.yml
+++ b/using-the-cluster/deploy-prometheus-grafana/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/using-the-cluster/deploy-prometheus-grafana/track_scripts/setup-crc
+++ b/using-the-cluster/deploy-prometheus-grafana/track_scripts/setup-crc
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi

--- a/using-the-cluster/deploying-images/01-01-creating-an-initial-project/assignment.md
+++ b/using-the-cluster/deploying-images/01-01-creating-an-initial-project/assignment.md
@@ -26,7 +26,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 - title: Visual Editor
   type: code

--- a/using-the-cluster/deploying-images/02-02-deploying-using-the-web-console/assignment.md
+++ b/using-the-cluster/deploying-images/02-02-deploying-using-the-web-console/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 - title: Visual Editor
   type: code

--- a/using-the-cluster/deploying-images/03-03-exploring-the-topology-view/assignment.md
+++ b/using-the-cluster/deploying-images/03-03-exploring-the-topology-view/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 - title: Visual Editor
   type: code

--- a/using-the-cluster/deploying-images/04-04-deleting-the-application/assignment.md
+++ b/using-the-cluster/deploying-images/04-04-deleting-the-application/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 - title: Visual Editor
   type: code
@@ -50,8 +50,8 @@ Labels:                 app=parksmap
                         app.kubernetes.io/part-of=parksmap-app
                         app.openshift.io/runtime-version=latest
 Annotations:            openshift.io/host.generated=true
-Requested Host:         parksmap-myproject.crc-gh9wd-master-0.crc.2fxr0dqhkd8a.instruqt.io
-                           exposed on router default (host router-default.crc-gh9wd-master-0.crc.2fxr0dqhkd8a.instruqt.io) 59 minutes ago
+Requested Host:         parksmap-myproject.crc-5nvrm-master-0.crc.2fxr0dqhkd8a.instruqt.io
+                           exposed on router default (host router-default.crc-5nvrm-master-0.crc.2fxr0dqhkd8a.instruqt.io) 59 minutes ago
 Path:                   <none>
 TLS Termination:        <none>
 Insecure Policy:        <none>

--- a/using-the-cluster/deploying-images/05-05-deploying-using-the-command-line/assignment.md
+++ b/using-the-cluster/deploying-images/05-05-deploying-using-the-command-line/assignment.md
@@ -13,7 +13,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 - title: Visual Editor
   type: code
@@ -117,10 +117,10 @@ You'll get output similar to the following
 
 ```
 NAME       HOST/PORT                                                            PATH   SERVICES   PORT       TERMINATION   WILDCARD
-parksmap   parksmap-myproject.crc-gh9wd-master-0.crc.2fxr0dqhkd8a.instruqt.io          parksmap   8080-tcp                 None
+parksmap   parksmap-myproject.crc-5nvrm-master-0.crc.2fxr0dqhkd8a.instruqt.io          parksmap   8080-tcp                 None
 ```
 
-Notice the output above has the URL `parksmap-myproject.crc-gh9wd-master-0.crc.2fxr0dqhkd8a.instruqt.io`.
+Notice the output above has the URL `parksmap-myproject.crc-5nvrm-master-0.crc.2fxr0dqhkd8a.instruqt.io`.
 
 This is the `route` to the new instance of the ParkMap application that was just installed. You can copy into a browser window to access the ParksMap application.
 

--- a/using-the-cluster/deploying-images/config.yml
+++ b/using-the-cluster/deploying-images/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/using-the-cluster/deploying-images/track_scripts/setup-crc
+++ b/using-the-cluster/deploying-images/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -209,3 +221,4 @@ done
 
 date
 echo "### Boostrap END ###"
+

--- a/using-the-cluster/deploying-python/01-01-creating-an-initial-project/assignment.md
+++ b/using-the-cluster/deploying-python/01-01-creating-an-initial-project/assignment.md
@@ -29,7 +29,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/using-the-cluster/deploying-python/02-02-deploying-using-the-web-console/assignment.md
+++ b/using-the-cluster/deploying-python/02-02-deploying-using-the-web-console/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/using-the-cluster/deploying-python/03-03-viewing-the-builder-logs/assignment.md
+++ b/using-the-cluster/deploying-python/03-03-viewing-the-builder-logs/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/using-the-cluster/deploying-python/04-04-accessing-the-application/assignment.md
+++ b/using-the-cluster/deploying-python/04-04-accessing-the-application/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/using-the-cluster/deploying-python/05-05-deleting-the-application/assignment.md
+++ b/using-the-cluster/deploying-python/05-05-deleting-the-application/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/using-the-cluster/deploying-python/06-06-deploying-using-the-command-line/assignment.md
+++ b/using-the-cluster/deploying-python/06-06-deploying-using-the-command-line/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300
@@ -129,7 +129,7 @@ You'll get output similar to the following:
 
 ```
 NAME             HOST/PORT                                                                  PATH   SERVICES         PORT       TERMINATION   WILDCARD
-blog-django-py   blog-django-py-myproject.crc-gh9wd-master-0.crc.pfrbfxh9ypu7.instruqt.io          blog-django-py   8080-tcp                 None
+blog-django-py   blog-django-py-myproject.crc-5nvrm-master-0.crc.pfrbfxh9ypu7.instruqt.io          blog-django-py   8080-tcp                 None
 ```
 
 # Congratulations!

--- a/using-the-cluster/deploying-python/07-07-triggering-a-new-build/assignment.md
+++ b/using-the-cluster/deploying-python/07-07-triggering-a-new-build/assignment.md
@@ -12,7 +12,7 @@ tabs:
   hostname: container
 - title: Web Console
   type: website
-  url: https://console-openshift-console.crc-gh9wd-master-0.crc.${_SANDBOX_ID}.instruqt.io
+  url: https://console-openshift-console.crc-5nvrm-master-0.crc.${_SANDBOX_ID}.instruqt.io
   new_window: true
 difficulty: basic
 timelimit: 300

--- a/using-the-cluster/deploying-python/config.yml
+++ b/using-the-cluster/deploying-python/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/using-the-cluster/deploying-python/track_scripts/setup-crc
+++ b/using-the-cluster/deploying-python/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -209,3 +221,4 @@ done
 
 date
 echo "### Boostrap END ###"
+

--- a/using-the-cluster/port-forwarding/config.yml
+++ b/using-the-cluster/port-forwarding/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/using-the-cluster/port-forwarding/track_scripts/setup-crc
+++ b/using-the-cluster/port-forwarding/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -209,3 +221,4 @@ done
 
 date
 echo "### Boostrap END ###"
+

--- a/using-the-cluster/resource-objects/02-02-resource-object-types/assignment.md
+++ b/using-the-cluster/resource-objects/02-02-resource-object-types/assignment.md
@@ -53,10 +53,10 @@ replicaset.apps/parksmap-7c4b487459   0         0         0       35s
 replicaset.apps/parksmap-867b495f94   1         1         1       35s
 
 NAME                                      IMAGE REPOSITORY                                                                                            TAGS    UPDATED
-imagestream.image.openshift.io/parksmap   default-route-openshift-image-registry.crc-gh9wd-master-0.crc.aa5od8iq5doy.instruqt.io/myproject/parksmap   1.3.0   35 seconds ago
+imagestream.image.openshift.io/parksmap   default-route-openshift-image-registry.crc-5nvrm-master-0.crc.aa5od8iq5doy.instruqt.io/myproject/parksmap   1.3.0   35 seconds ago
 
 NAME                                HOST/PORT                                                            PATH   SERVICES   PORT       TERMINATION   WILDCARD
-route.route.openshift.io/parksmap   parksmap-myproject.crc-gh9wd-master-0.crc.aa5od8iq5doy.instruqt.io          parksmap   8080-tcp                 None            None
+route.route.openshift.io/parksmap   parksmap-myproject.crc-5nvrm-master-0.crc.aa5od8iq5doy.instruqt.io          parksmap   8080-tcp                 None            None
 ```
 
 You can use the `-o name` option to restrict output to show only the names of the resources.
@@ -93,7 +93,7 @@ You'll see output similar to the following:
 
 ```
 NAME       HOST/PORT                                                            PATH   SERVICES   PORT       TERMINATION   WILDCARD
-parksmap   parksmap-myproject.crc-gh9wd-master-0.crc.aa5od8iq5doy.instruqt.io          parksmap   8080-tcp                 None
+parksmap   parksmap-myproject.crc-5nvrm-master-0.crc.aa5od8iq5doy.instruqt.io          parksmap   8080-tcp                 None
 ```
 
 # Listing the OpenShift resource objects
@@ -141,7 +141,7 @@ You'll get output similar to the following:
 
 ```
 NAME       HOST/PORT                                                            PATH   SERVICES   PORT       TERMINATION   WILDCARD
-parksmap   parksmap-myproject.crc-gh9wd-master-0.crc.ejsovmyiskmk.instruqt.io          parksmap   8080-tcp                 None
+parksmap   parksmap-myproject.crc-5nvrm-master-0.crc.ejsovmyiskmk.instruqt.io          parksmap   8080-tcp                 None
 ```
 
 Notice that the result above shows the URL to use to access the particular application on the Internet. This URL was created automatically by OpenShift.

--- a/using-the-cluster/resource-objects/03-03-querying-resource-objects/assignment.md
+++ b/using-the-cluster/resource-objects/03-03-querying-resource-objects/assignment.md
@@ -39,8 +39,8 @@ Labels:                 app=parksmap
                         app.kubernetes.io/component=parksmap
                         app.kubernetes.io/instance=parksmap
 Annotations:            openshift.io/host.generated=true
-Requested Host:         parksmap-myproject.crc-gh9wd-master-0.crc.vzc8lf1zaimp.instruqt.io
-                           exposed on router default (host router-default.crc-gh9wd-master-0.crc.vzc8lf1zaimp.instruqt.io) 2 minutes ago
+Requested Host:         parksmap-myproject.crc-5nvrm-master-0.crc.vzc8lf1zaimp.instruqt.io
+                           exposed on router default (host router-default.crc-5nvrm-master-0.crc.vzc8lf1zaimp.instruqt.io) 2 minutes ago
 Path:                   <none>
 TLS Termination:        <none>
 Insecure Policy:        <none>

--- a/using-the-cluster/resource-objects/05-05-creating-resource-objects/assignment.md
+++ b/using-the-cluster/resource-objects/05-05-creating-resource-objects/assignment.md
@@ -106,7 +106,7 @@ You get results as follows:
 
 ```
 NAME            HOST/PORT                                                            PATH   SERVICES   PORT       TERMINATION   WILDCARD
-parksmap        parksmap-myproject.crc-gh9wd-master-0.crc.dlzdxnbljgoz.instruqt.io          parksmap   8080-tcp                 None
+parksmap        parksmap-myproject.crc-5nvrm-master-0.crc.dlzdxnbljgoz.instruqt.io          parksmap   8080-tcp                 None
 parksmap-fqdn   www.example.com                                                             parksmap   8080-tcp   edge/Allow    None                                                      parksmap   8080-tcp   edge/Allow    None
 ```
 
@@ -142,7 +142,7 @@ You'll get output similar to the following:
 
 ```
 NAME             HOST/PORT                                                            PATH   SERVICES   PORT       TERMINATION   WILDCARD
-parksmap         parksmap-myproject.crc-gh9wd-master-0.crc.xdos3cn6o5qf.instruqt.io          parksmap   8080-tcp                 None
+parksmap         parksmap-myproject.crc-5nvrm-master-0.crc.xdos3cn6o5qf.instruqt.io          parksmap   8080-tcp                 None
 parksmap-fqdn    www.example.com                                                             parksmap   8080-tcp   edge/Allow    None
 parksmap-fqdn2   www.otherexample.com                                                        parksmap   8080-tcp   edge/Allow    None
 ```

--- a/using-the-cluster/resource-objects/config.yml
+++ b/using-the-cluster/resource-objects/config.yml
@@ -5,7 +5,7 @@ containers:
   shell: /bin/bash
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/using-the-cluster/resource-objects/track_scripts/setup-crc
+++ b/using-the-cluster/resource-objects/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -209,3 +221,4 @@ done
 
 date
 echo "### Boostrap END ###"
+

--- a/using-the-cluster/resource-objects/using-the-cluster-resource-objects/track_scripts/setup-crc
+++ b/using-the-cluster/resource-objects/using-the-cluster-resource-objects/track_scripts/setup-crc
@@ -5,21 +5,15 @@ set -x
 export TERM=xterm-color
 export KUBECONFIG=/opt/kubeconfig
 
-# save them to the profile
-echo "export TERM=xterm-color" >> /root/.bashrc
-echo "export KUBECONFIG=/opt/kubeconfig" >> /root/.bashrc
-
 ENS4IP=$(ip -4 -o addr show ens4 | awk '{print $4}' | cut -d "/" -f 1)
 
 # set hostname
-INSTRUQT_HOSTNAME=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/hostname)
+#INSTRUQT_HOSTNAME=$(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/hostname)
 
 # Don't do this below causes issues later on, i believe.
 # hostnamectl set-hostname $HOSTNAME
 
 eval $(curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/startup-script | grep INSTRUQT_PARTICIPANT_ID)
-
-PULLSECRET="eyJhdXRocyI6eyJjbG91ZC5vcGVuc2hpZnQuY29tIjp7ImF1dGgiOiJiM0JsYm5Ob2FXWjBMWEpsYkdWaGMyVXRaR1YySzJKbGJtOWpaV3h2ZEhWd2NtOWhjbU52YlRGeWVYUndjamwyYVcxc2VHcDJiR1JpTjNka2JEUnhZMnBpY0RwSk0weFNRVUU0VTBoVVNGUXpVbGhCVnpOSVZFaFNRVkZSUjBFMU5rNUZVVlZPUVZGSFNEZElPVnBCVGs5UFdUSktTbFJPVHpOV1FVaEZSMGRHTkRkTSIsImVtYWlsIjoiYmVuQG9jZWxvdHVwcm9hci5jb20ifSwicXVheS5pbyI6eyJhdXRoIjoiYjNCbGJuTm9hV1owTFhKbGJHVmhjMlV0WkdWMksySmxibTlqWld4dmRIVndjbTloY21OdmJURnllWFJ3Y2psMmFXMXNlR3AyYkdSaU4zZGtiRFJ4WTJwaWNEcEpNMHhTUVVFNFUwaFVTRlF6VWxoQlZ6TklWRWhTUVZGUlIwRTFOazVGVVZWT1FWRkhTRGRJT1ZwQlRrOVBXVEpLU2xST1R6TldRVWhGUjBkR05EZE0iLCJlbWFpbCI6ImJlbkBvY2Vsb3R1cHJvYXIuY29tIn0sInJlZ2lzdHJ5LmNvbm5lY3QucmVkaGF0LmNvbSI6eyJhdXRoIjoiTlRJNE9UUTBOekI4ZFdoakxURlNXVlJRY2psMlNVMU1XRXBXVEVSQ04xZEVURFJ4WTJwQ2NEcGxlVXBvWWtkamFVOXBTbE5WZWxWNFRXbEtPUzVsZVVwNlpGZEphVTlwU210UFIwWnNUVlJzYWxreVNtdE9WRUV3VGxkTmVsbHRVVEJhYlZwcldsUktiVnBFVlRKT1JFbDVUV2xLT1M1d1lrTjNXVXBoVFZSZlRXazRSVzlzYlRaM016RTFXbWd5VUVaWGREQTBiMVl6YlZkWFF6SlFUbmhoVkVWa1VuWkxORmhWV1dRdFNWaHdWMVZhVDJONlIwUTVNbEZCVVUwMmExQXphekZpZVhSRGVqZEVVVXRRWm10TWNsRndlbGg2ZEROa2J6TTFPRTR6Vmtob01tVlZSMVJ3Vkc1WExWVjNVVzVtU2pCRk4zRXRiM1JOZVRaQlpGZ3hhbVJQUkRWbGRuVjNYMnBDYjNSbk1sbE1VQzFETjNSU1pHdFlkekZXUjNOSE0zZHlOMkkxVjJsb1VEUnlkRlZaUjJoTFQxbDNVRTF5V0d0UWFGUlNaRXN0WVVGeGRtTXpNa1ZrVlZaVU9HOUdYMWhLUzFkVmFYRnVjMVZLWjBwaWRFUllWRTUyU1d0TmIxTmhVVFJyUW0xNlVGUlVNVEpWY2pWdk5GRlRWa1ZCU1ZOamN6ZERhVVZUT1doUWFtNXljVUpZVXpKbFpXRlNRbFZOWkRaeFMwNU9OR2xqWm1oTFRUbHpWbko0ZVhSRlJYWTBjbTVTUW1Wa00xTTBaV2xoVkdObVgxcEdTblYxZURrNFJVMVhjWFZEUTNJNGFHMWZPRWRtY0ZKUVNXNHlZVlp2Y2w5RVNrZDJNbEJZV2kwdFpIZFZhVE5uY0hjNVFrUlFRemhRUVhWS1pWRTRXa1J5WkVvMFdYVmhNRWxLYUdwNk5HdE1ZM0ZwWTNOVU1ITm1jVTVJZGw5cWR6aENVbXBhZDFZdE4yRkpkM0EyVGxnd1VXSlNhWFJ2WW5ORGNtaEtYMVZRVUd4TVZYTjNOekp4VTNCNFVFUlRVMjVOUmpsdVRIUlJPVEEyUlhCTWFtdEZhMDVUTkhJeFJEZDVVa2RwVFVzeGEySTRXalJRZGtOelpUVnJaV3hmZEhOSmNVMTBhRGRIWDFoT1oxUlVlR3hmZVVGcllYVk9NMHB4TUY5WVlUQTBWVzF6ZVZwaFJVZFVSVnBmVjNoQkxXdFFaMDFKV2tvNFZIRkhVRU5zT0dJd0xYQkZWR0pIZEhJdGJWbERWSFkxYTBaMVVtMWlRVjlxWkVrNFlUTjRVVzFIVXpCVFZ6aHdMVVpmVUVOSFMyaHZTWGcyU21SbVRUVnNTbVZaVG1seGVIUnJVV3hXTFhWemNreG5WV05TZFRaTlgzSmZSMWd4VlE9PSIsImVtYWlsIjoiYmVuQG9jZWxvdHVwcm9hci5jb20ifSwicmVnaXN0cnkucmVkaGF0LmlvIjp7ImF1dGgiOiJOVEk0T1RRME56QjhkV2hqTFRGU1dWUlFjamwyU1UxTVdFcFdURVJDTjFkRVREUnhZMnBDY0RwbGVVcG9Za2RqYVU5cFNsTlZlbFY0VFdsS09TNWxlVXA2WkZkSmFVOXBTbXRQUjBac1RWUnNhbGt5U210T1ZFRXdUbGROZWxsdFVUQmFiVnByV2xSS2JWcEVWVEpPUkVsNVRXbEtPUzV3WWtOM1dVcGhUVlJmVFdrNFJXOXNiVFozTXpFMVdtZ3lVRVpYZERBMGIxWXpiVmRYUXpKUVRuaGhWRVZrVW5aTE5GaFZXV1F0U1Zod1YxVmFUMk42UjBRNU1sRkJVVTAyYTFBemF6RmllWFJEZWpkRVVVdFFabXRNY2xGd2VsaDZkRE5rYnpNMU9FNHpWa2hvTW1WVlIxUndWRzVYTFZWM1VXNW1TakJGTjNFdGIzUk5lVFpCWkZneGFtUlBSRFZsZG5WM1gycENiM1JuTWxsTVVDMUROM1JTWkd0WWR6RldSM05ITTNkeU4ySTFWMmxvVURSeWRGVlpSMmhMVDFsM1VFMXlXR3RRYUZSU1pFc3RZVUZ4ZG1Nek1rVmtWVlpVT0c5R1gxaEtTMWRWYVhGdWMxVktaMHBpZEVSWVZFNTJTV3ROYjFOaFVUUnJRbTE2VUZSVU1USlZjalZ2TkZGVFZrVkJTVk5qY3pkRGFVVlRPV2hRYW01eWNVSllVekpsWldGU1FsVk5aRFp4UzA1T05HbGpabWhMVFRselZuSjRlWFJGUlhZMGNtNVNRbVZrTTFNMFpXbGhWR05tWDFwR1NuVjFlRGs0UlUxWGNYVkRRM0k0YUcxZk9FZG1jRkpRU1c0eVlWWnZjbDlFU2tkMk1sQllXaTB0WkhkVmFUTm5jSGM1UWtSUVF6aFFRWFZLWlZFNFdrUnlaRW8wV1hWaE1FbEthR3A2Tkd0TVkzRnBZM05VTUhObWNVNUlkbDlxZHpoQ1VtcGFkMVl0TjJGSmQzQTJUbGd3VVdKU2FYUnZZbk5EY21oS1gxVlFVR3hNVlhOM056SnhVM0I0VUVSVFUyNU5Samx1VEhSUk9UQTJSWEJNYW10RmEwNVROSEl4UkRkNVVrZHBUVXN4YTJJNFdqUlFka056WlRWclpXeGZkSE5KY1UxMGFEZEhYMWhPWjFSVWVHeGZlVUZyWVhWT00wcHhNRjlZWVRBMFZXMXplVnBoUlVkVVJWcGZWM2hCTFd0UVowMUpXa280VkhGSFVFTnNPR0l3TFhCRlZHSkhkSEl0YlZsRFZIWTFhMFoxVW0xaVFWOXFaRWs0WVRONFVXMUhVekJUVnpod0xVWmZVRU5IUzJodlNYZzJTbVJtVFRWc1NtVlpUbWx4ZUhSclVXeFdMWFZ6Y2t4blZXTlNkVFpOWDNKZlIxZ3hWUT09IiwiZW1haWwiOiJiZW5Ab2NlbG90dXByb2FyLmNvbSJ9fX0K"
 
 # dnsmasq config for crc-dnsmasq.service
 cat << EOF > /var/srv/dnsmasq.conf
@@ -33,14 +27,10 @@ domain=crc.testing
 address=/apps-crc.testing/$ENS4IP
 address=/api.crc.testing/$ENS4IP
 address=/api-int.crc.testing/$ENS4IP
-address=/crc-dzk9v-master-0.crc.testing/192.168.126.11
+address=/$HOSTNAME.crc.testing/192.168.126.11
 EOF
 
-# configure local resolver
 sed -i '/^search.*/a nameserver 10.88.0.8' /etc/resolv.conf
-
-# Set kubelet config.json
-echo "$PULLSECRET" | base64 -d | tee /var/lib/kubelet/config.json
 
 # start openshift
 systemctl start crc-dnsmasq.service
@@ -82,59 +72,50 @@ then
   oc get csr -oname | xargs oc adm certificate approve
 fi
 
-# place yaml
-cat << EOF > /tmp/pull-secret.yaml
-apiVersion: v1
-data:
-  .dockerconfigjson: $PULLSECRET
-kind: Secret
-metadata:
-  name: pull-secret
-  namespace: openshift-config
-type: kubernetes.io/dockerconfigjson
-EOF
+# Wait a little bit for all pods to start
+# Check with crictl ps
+echo "### Boostrap START ###"
+date
 
-# setup the pull secret for the cluster
-until oc replace -f /tmp/pull-secret.yaml 2>/dev/null 1>&2; do echo "Resetting pull secret. This fails when the apiserver is not ready."; sleep 5; done
+until oc get pods -A 2>/dev/null 1>&2; do 
+  echo "Waiting for pods to start..";
+  sleep 5;
+done
 
-rm /tmp/pull-secret.yaml
-# OpenShift should start to be avilable at this point. `oc get co`, wait till all are true to be sure!
-# probably optional? more stable though.
+until oc get co 2>/dev/null 1>&2; do 
+  echo "Waiting for Cluster Operators to complete first rollout";
+  sleep 5;
+done
+
+for co in $(oc get co -oname)
+do
+    # skip this one
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
+    then
+      continue
+    fi
+
+    echo -n "Waiting for $co ..."
+    co_available=$(oc get $co 2>/dev/null | awk -v col=AVAILABLE 'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}} print $c} NR>1{print $c}' | grep True)
+
+    while [ "${co_available}" == "" ]
+    do
+      sleep 5
+      echo -n "."
+      co_available=$(oc get $co 2>/dev/null | awk -v col=AVAILABLE 'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}} print $c} NR>1{print $c}' | grep True)
+    done
+    echo "AVAILABLE"
+done
 
 
-# admin/admin, @Maybe fixing the TODO above (wait for oc get co == true ...) this will actually work?
-cat << EOF > /tmp/pass.htpasswd
-admin:\$2y\$05\$Sokv3so/TbycwilNeV6L6.lMIYT0ClbaW/RsPssFIBY.BWanJyMwe
-developer:\$apr1\$PFGWfRKw\$DbBab3TIlvsZGmHjVbehv0
-EOF
-
-cat << EOF > /tmp/oauth-admin.yaml
-apiVersion: config.openshift.io/v1
-kind: OAuth
-metadata:
-  name: cluster
-spec:
-  identityProviders:
-  - name: admin_htpasswd_provider
-    mappingMethod: claim
-    type: HTPasswd
-    htpasswd:
-      fileData:
-        name: htpass-secret-admin
-EOF
-
-until oc create secret generic htpass-secret-admin --from-file=htpasswd=/tmp/pass.htpasswd -n openshift-config 2>/dev/null 1>&2; do echo "Add admin secret. This fails when the apiserver is not ready."; sleep 5; done
-until oc apply -f /tmp/oauth-admin.yaml 2>/dev/null 1>&2; do echo "Adding admin user. This fails when the apiserver is not ready."; sleep 5; done
-until oc adm policy add-cluster-role-to-user cluster-admin admin 2>/dev/null 1>&2; do echo "Config admin policy. This fails when the apiserver is not ready."; sleep 5; done
-
-until oc adm policy add-cluster-role-to-user cluster-admin admin 2>/dev/null 1>&2; do echo "Config admin policy. This fails when the apiserver is not ready."; sleep 5; done
-
-rm /tmp/oauth-admin.yaml /tmp/pass.htpasswd
 
 # INGRESS
 
 # check if ingresses.config.openshift.io cluster is present
 oc patch -p '{"spec": {"domain": "'$HOSTNAME'.crc.'$INSTRUQT_PARTICIPANT_ID'.instruqt.io"}}' ingresses.config.openshift.io cluster --type=merge
+
+# Wait 30 seconds for the old pod to be terminated
+sleep 30
 
 oc delete -n openshift-ingress-operator ingresscontroller/default
 
@@ -164,23 +145,80 @@ oc patch -p '{"spec": {"host": "downloads-openshift-console.'$HOSTNAME'.crc.'$IN
 oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAME'.crc.'$INSTRUQT_PARTICIPANT_ID'.instruqt.io"}}' route default-route -n openshift-image-registry --type=merge
 
 
-# wait until cluster operators are "available"
-# for co in $(oc get co -oname)
-# do
-#     # skip this one
-#     if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
-#     then
-#       continue
-#     fi
-#     
-#     echo -n "Waiting for $co ..."
-#     co_available=$(oc get $co 2>/dev/null | awk -v col=AVAILABLE 'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}} print $c} NR>1{print $c}' | grep True)
-# 
-#     while [ "${co_available}" == "" ]
-#     do
-#       sleep 5
-#       echo -n "."
-#       co_available=$(oc get $co 2>/dev/null | awk -v col=AVAILABLE 'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}} print $c} NR>1{print $c}' | grep True)
-#     done
-#     echo "AVAILABLE"
-# done
+#wait until cluster operators are "available"
+for co in $(oc get co -oname)
+do
+    # skip this one
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
+    then
+      continue
+    fi
+
+    echo -n "Waiting for $co ..."
+    co_available=$(oc get $co 2>/dev/null | awk -v col=AVAILABLE 'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}} print $c} NR>1{print $c}' | grep True)
+
+    while [ "${co_available}" == "" ]
+    do
+      sleep 5
+      echo -n "."
+      co_available=$(oc get $co 2>/dev/null | awk -v col=AVAILABLE 'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}} print $c} NR>1{print $c}' | grep True)
+    done
+    echo "AVAILABLE"
+
+    co_progressing=$(oc get $co 2>/dev/null | awk -v col=PROGRESSING 'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}} print $c} NR>1{print $c}' | grep False)
+
+    while [ "${co_progressing}" == "" ]
+    do
+      echo "Cluster Operator $co still progressing"
+      sleep 5
+      echo -n "."
+      co_progressing=$(oc get $co 2>/dev/null | awk -v col=PROGRESSING 'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}} print $c} NR>1{print $c}' | grep False)
+    done
+done
+
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
+# do twice since cluster operator rolls out continuously
+for co in $(oc get co -oname)
+do
+    # skip this one
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
+    then
+      continue
+    fi
+
+    echo -n "Waiting for $co ..."
+    co_available=$(oc get $co 2>/dev/null | awk -v col=AVAILABLE 'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}} print $c} NR>1{print $c}' | grep True)
+
+    while [ "${co_available}" == "" ]
+    do
+      sleep 5
+      echo -n "."
+      co_available=$(oc get $co 2>/dev/null | awk -v col=AVAILABLE 'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}} print $c} NR>1{print $c}' | grep True)
+    done
+    echo "AVAILABLE"
+
+    co_progressing=$(oc get $co 2>/dev/null | awk -v col=PROGRESSING 'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}} print $c} NR>1{print $c}' | grep False)
+
+    while [ "${co_progressing}" == "" ]
+    do
+      echo "Cluster Operator $co still progressing"
+      sleep 5
+      echo -n "."
+      co_progressing=$(oc get $co 2>/dev/null | awk -v col=PROGRESSING 'NR==1{for(i=1;i<=NF;i++){if($i==col){c=i;break}} print $c} NR>1{print $c}' | grep False)
+    done
+done
+
+date
+echo "### Boostrap END ###"
+

--- a/using-the-cluster/transferring-files/02-02-downloading-files-from-a-container/assignment.md
+++ b/using-the-cluster/transferring-files/02-02-downloading-files-from-a-container/assignment.md
@@ -124,7 +124,7 @@ export APP_ROUTE=`oc get route simplemessage -n myproject -o jsonpath='{"http://
 You'll get output similar to the following:
 
 ```
-http://simplemessage-myproject.crc-gh9wd-master-0.crc.ogrx0anbjp74.instruqt.io
+http://simplemessage-myproject.crc-5nvrm-master-0.crc.ogrx0anbjp74.instruqt.io
 ```
 
 Remember: The output shown above is special to this running instance of OpenShift. The URL you get when you run this track will be different.

--- a/using-the-cluster/transferring-files/03-03-uploading-files-to-a-container/assignment.md
+++ b/using-the-cluster/transferring-files/03-03-uploading-files-to-a-container/assignment.md
@@ -102,7 +102,7 @@ export APP_ROUTE=`oc get route simplemessage -n myproject -o jsonpath='{"http://
 You'll get output similar to the following:
 
 ```
-http://simplemessage-myproject.crc-gh9wd-master-0.crc.ai7oaxyso7ih.instruqt.io
+http://simplemessage-myproject.crc-5nvrm-master-0.crc.ai7oaxyso7ih.instruqt.io
 ```
 
 The output above is the URL to the SimpleMessage application running in this OpenShift cluster. The URL you create will be different. Remember: The actual structure of the URL is special to the running instance of OpenShift.

--- a/using-the-cluster/transferring-files/04-04-synchronizing-files-with-a-container/assignment.md
+++ b/using-the-cluster/transferring-files/04-04-synchronizing-files-with-a-container/assignment.md
@@ -126,7 +126,7 @@ export APP_ROUTE=`oc get route simplemessage -n myproject -o jsonpath='{"http://
 You'll get output similar to the following. (Your actual URL will be different):
 
 ```
-http://simplemessage-myproject.crc-gh9wd-master-0.crc.ai7oaxyso7ih.instruqt.io
+http://simplemessage-myproject.crc-5nvrm-master-0.crc.ai7oaxyso7ih.instruqt.io
 ```
 
 ----

--- a/using-the-cluster/transferring-files/config.yml
+++ b/using-the-cluster/transferring-files/config.yml
@@ -1,7 +1,7 @@
 version: "3"
 virtualmachines:
 - name: crc
-  image: openshift-instruqt/crc-4-10-latest
+  image: openshift-instruqt/crc-4-10-18
   machine_type: n1-highmem-4
   allow_external_ingress:
   - http

--- a/using-the-cluster/transferring-files/track_scripts/setup-crc
+++ b/using-the-cluster/transferring-files/track_scripts/setup-crc
@@ -77,7 +77,7 @@ fi
 echo "### Boostrap START ###"
 date
 
-until oc get pods -A 2>/dev/null 1>&2; do
+until oc get pods -A 2>/dev/null 1>&2; do 
   echo "Waiting for pods to start..";
   sleep 5;
 done
@@ -90,7 +90,7 @@ done
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -149,7 +149,7 @@ oc patch -p '{"spec": {"host": "default-route-openshift-image-registry.'$HOSTNAM
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -176,11 +176,23 @@ do
     done
 done
 
+
+### YOUR SETUP SCRIPT (E.G. INSTALL JDK, GO ETC) SHOULD GO HERE 
+# In this way we try to optimize the flow while we wait for oauth and routes to be finally OK
+# https://bugzilla.redhat.com/show_bug.cgi?id=2082539
+
+###
+
+until [[ `oc get routes -A | awk '!/^(NAME|openshift-ingress-canary)/{print$3}' |grep 5nvrm` ]]; do 
+    echo "Routes not patched yet, waiting 30 seconds..";
+    sleep 30;
+done
+
 # do twice since cluster operator rolls out continuously
 for co in $(oc get co -oname)
 do
     # skip this one
-    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.ioopenshift-controller-manager" ]
+    if [ $co == "clusteroperator.config.openshift.io/machine-config" -o $co == "clusteroperator.config.openshift.io/openshift-controller-manager" ]
     then
       continue
     fi
@@ -209,3 +221,4 @@ done
 
 date
 echo "### Boostrap END ###"
+


### PR DESCRIPTION
Update to latest CRC image with this strategy:

- The cluster operator behavior changed, they look immediately OK but the routes are not patched after a while. So we check routes and CO again
- Any setup script (install java etc) should be put before those checks so we might save time
- It's not possible to change the hostname so that we use always the same for Web Console URL, updating it again
- Using an image name of form: `openshift-instruqt/crc-4-<major>-<minor>` as convention, is good we track all version changes

The wait time is between 11-13 min

A test playground is [here](https://play.instruqt.com/openshift/tracks/playground-test/c)

This should fix #128 and unblock #122

